### PR TITLE
Hide payfac mp php and python

### DIFF
--- a/_includes/sdk.html
+++ b/_includes/sdk.html
@@ -37,14 +37,15 @@
 					<li class="{% if page.title == 'DotNet' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}dotnet" class="btn-default"  id="cnp-sdk-dotnet">.NET</a>
 					</li>
-					<!--Commenting php and python mp sdks-->
 
-					<!--<li class="{% if page.title == 'PHP' %}active{% endif %}">
+					{% if page.type != 'payfac' %}
+					<li class="{% if page.title == 'PHP' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}php" class="btn-default" id="cnp-sdk-php">PHP</a>
 					</li>
 					<li class="{% if page.title == 'Python' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}python" class="btn-default" id="cnp-sdk-python">Python</a>
-					</li>-->
+					</li>
+					{% endif %}
 				</ol>
 			</div>
 			{% endif %}

--- a/_includes/sdk.html
+++ b/_includes/sdk.html
@@ -37,12 +37,14 @@
 					<li class="{% if page.title == 'DotNet' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}dotnet" class="btn-default"  id="cnp-sdk-dotnet">.NET</a>
 					</li>
-					<li class="{% if page.title == 'PHP' %}active{% endif %}">
+					<!--Commenting php and python mp sdks-->
+
+					<!--<li class="{% if page.title == 'PHP' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}php" class="btn-default" id="cnp-sdk-php">PHP</a>
 					</li>
 					<li class="{% if page.title == 'Python' %}active{% endif %}">
 						<a href="../{% if page.type == 'cbk' %}cbk-{% endif %}{% if page.type == 'payfac' %}payfac-{% endif %}python" class="btn-default" id="cnp-sdk-python">Python</a>
-					</li>
+					</li>-->
 				</ol>
 			</div>
 			{% endif %}

--- a/latest-versions/content.md
+++ b/latest-versions/content.md
@@ -28,6 +28,12 @@ SDK versioning is done in format XX.YY.ZZ
 
 ### PayFac MP SDKs:
 
-| Version | Java | .NET | Python | PHP |
+| Version | Java | .NET 
+| ------ | ---- | ---- 
+| 13 | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-java/releases/tag/13.0.0) | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-dotnet/releases/tag/13.0.0)
+
+
+<!-- Removing python and php from Payfac MP SDKs -->
+<!--| Version | Java | .NET | Python | PHP |
 | ------ | ---- | ---- | ---- | --- |
-| 13 | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-java/releases/tag/13.0.0) | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-dotnet/releases/tag/13.0.0) | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-python/releases/tag/13.0.0) |[13.0.0](https://github.com/Vantiv/payfac-mp-sdk-php/releases/tag/13.0.0) |
+| 13 | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-java/releases/tag/13.0.0) | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-dotnet/releases/tag/13.0.0) | [13.0.0](https://github.com/Vantiv/payfac-mp-sdk-python/releases/tag/13.0.0) |[13.0.0](https://github.com/Vantiv/payfac-mp-sdk-php/releases/tag/13.0.0) |-->

--- a/latest-versions/index.html
+++ b/latest-versions/index.html
@@ -136,8 +136,9 @@ content-description: ""
                             <th scope="col" class="col-md-3">PayFac MP API Version</th>
                             <th scope="col" class="col-md-2">Java</th>
                             <th scope="col" class="col-md-2">.NET</th>
-                            <th scope="col" class="col-md-2">Python</th>
-                            <th scope="col" class="col-md-2">PHP</th>
+                            <!--Removing payfac-mp-sdk-python and payfac-mp-sdk-php from latest Version page-->
+                         <!--   <th scope="col" class="col-md-2">Python</th>
+                            <th scope="col" class="col-md-2">PHP</th>-->
                         </tr>
                         </thead>
                         <tbody>

--- a/latest-versions/index.html
+++ b/latest-versions/index.html
@@ -150,13 +150,14 @@ content-description: ""
                                     href="https://github.com/Vantiv/payfac-mp-sdk-dotnet/releases/latest"><img
                                     src="https://img.shields.io/github/release/vantiv/payfac-mp-sdk-dotnet.svg" alt=""></a>
                             </td>
-                            <td scope="row"><a
+                            <!--Removing payfac-mp-sdk-python and payfac-mp-sdk-php from latest Version page-->
+                         <!--   <td scope="row"><a
                                     href="https://github.com/Vantiv/payfac-mp-sdk-python/releases/latest"><img
                                     src="https://img.shields.io/github/release/vantiv/payfac-mp-sdk-python.svg" alt=""></a>
                             </td>
                             <td scope="row"><a href="https://github.com/Vantiv/payfac-mp-sdk-php/releases/latest"><img
                                     src="https://img.shields.io/github/release/vantiv/payfac-mp-sdk-php.svg" alt=""></a>
-                            </td>
+                            </td>-->
                         </tr>
                         </tbody>
                     </table>

--- a/latest-versions/index.html
+++ b/latest-versions/index.html
@@ -145,7 +145,7 @@ content-description: ""
                         </thead>
                         <tbody>
                         <tr>
-                            <td scope="row">14.x</td>
+                            <td scope="row">15.x</td>
                             <td scope="row"><a href="https://github.com/Vantiv/payfac-mp-sdk-java/releases/latest"><img
                                     src="https://img.shields.io/github/release/vantiv/payfac-mp-sdk-java.svg" alt=""></a>
                             </td>

--- a/latest-versions/index.html
+++ b/latest-versions/index.html
@@ -37,7 +37,8 @@ content-description: ""
                         <tr>
                             <td scope="row">12.x</td>
                             <td scope="row"><a href="https://github.com/Vantiv/cnp-sdk-for-java/releases/latest"><img
-                                    src="https://img.shields.io/github/release/vantiv/cnp-sdk-for-java.svg" alt=""></td>
+                                    src="https://img.shields.io/github/release/vantiv/cnp-sdk-for-java.svg" alt=""></a>
+                            </td>
                             <td scope="row"><a href="https://github.com/Vantiv/cnp-sdk-for-dotnet/releases/latest"><img
                                     src="https://img.shields.io/github/release/vantiv/cnp-sdk-for-dotnet.svg"
                                     alt=""></a></td>
@@ -46,7 +47,8 @@ content-description: ""
                                     src="https://img.shields.io/github/release/vantiv/vantiv-sdk-for-python.svg" alt=""></a>
                             </td>
                             <td scope="row"><a href="https://github.com/Vantiv/cnp-sdk-for-php/releases/latest"><img
-                                    src="https://img.shields.io/github/release/vantiv/cnp-sdk-for-php.svg" alt=""></td>
+                                    src="https://img.shields.io/github/release/vantiv/cnp-sdk-for-php.svg" alt=""></a>
+                            </td>
                         </tr>
                         <tr>
                             <td scope="row">11.x</td>


### PR DESCRIPTION
- Making payfac-mp-sdk-for-php and payfac-mp-sdk-for-python repositories as private